### PR TITLE
seccomp: catchViolation() reports incorrect syscall numbers

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -36,7 +36,7 @@
 static void catchViolation(int sig, siginfo_t* si, void* threadContext)
 {
     printf("Attempted banned syscall number [%d] see doc/Seccomp.md for more information\n",
-           si->si_value.sival_int);
+           si->si_syscall);
     Assert_failure("Disallowed Syscall");
 }
 


### PR DESCRIPTION
Something like:
> Attempted banned syscall number [1073741864] see doc/Seccomp.md for more information

`catchViolation()` prints `siginfo_t.si_value.sival_int`, but should instead use `siginfo_t.si_syscall`.

This is how the syscall number is set in the kernel ([seccomp_send_sigsys()](http://lxr.free-electrons.com/ident?i=seccomp_send_sigsys) in [kernel/seccomp.c](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/kernel/seccomp.c)):
```c
	info.si_syscall = syscall;
```

siginfo_t is defined in <[bits/siginfo.h](http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/siginfo.h)>. The definition varies, but I guess `si_syscall` should be defined wherever seccomp syscall filters are available.