### PR TITLE
seccomp: failure to report blocked syscall number on Raspberry Pi

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -259,6 +259,9 @@ static struct sock_fprog* mkFilter(struct Allocator* alloc, struct Except* eh)
 
         // printf()
         IFEQ(__NR_fstat, success),
+        #ifdef __NR_fstat64
+            IFEQ(__NR_fstat64, success),
+        #endif
 
         RET(SECCOMP_RET_TRAP),
 


### PR DESCRIPTION
The SIGSYS handler tries to print the blocked syscall number. printf() uses another banned syscall, which results in another SIGSYS in the signal handler, which crashes the process without any output.