### PR TITLE
Init script, contrib/python enhancements, crash detection and restart for Gentoo

### DIFF
--- a/contrib/gentoo/README.md
+++ b/contrib/gentoo/README.md
@@ -4,12 +4,16 @@
 
 Copy the the openrc init script from `contrib/openrc` to `/etc/init.d/` and modify the `CONFFILE` and `command` parameter to your needs. 
 Then start cjdns by issuing
+
     /etc/init.d/cjdns start
+
 Configure the init system to autostart cjdns
+
     rc-update add cjdns default
 
 Copy the service_restart script `contrib/gentoo/service_restart.sh` to any convenient directory on 
 your system and modify the eMail address. I you do not wish to be notified, comment out the whole line.
 Now add an crontab entry like this
+
     # Restart crashed Services
     * * * * *       root	/path/to/script/service_restart.sh

--- a/contrib/gentoo/README.md
+++ b/contrib/gentoo/README.md
@@ -1,0 +1,15 @@
+# Gentoo
+
+## Automatic crash detection and restart
+
+Copy the the openrc init script from `contrib/openrc` to `/etc/init.d/` and modify the `CONFFILE` and `command` parameter to your needs. 
+Then start cjdns by issuing
+ /etc/init.d/cjdns start
+Configure the init system to autostart cjdns
+ rc-update add cjdns default
+
+Copy the service_restart script `contrib/gentoo/service_restart.sh` to any convenient directory on 
+your system and modify the eMail address. I you do not wish to be notified, comment out the whole line.
+Now add an crontab entry like this
+ # Restart crashed Services
+ * * * * *       root	/path/to/script/service_restart.sh

--- a/contrib/gentoo/README.md
+++ b/contrib/gentoo/README.md
@@ -12,7 +12,7 @@ Configure the init system to autostart cjdns
     rc-update add cjdns default
 
 Copy the service_restart script `contrib/gentoo/service_restart.sh` to any convenient directory on 
-your system and modify the eMail address. I you do not wish to be notified, comment out the whole line.
+your system and modify the eMail address. If you do not wish to be notified, comment out the whole line.
 Now add an crontab entry like this
 
     # Restart crashed Services

--- a/contrib/gentoo/README.md
+++ b/contrib/gentoo/README.md
@@ -4,12 +4,12 @@
 
 Copy the the openrc init script from `contrib/openrc` to `/etc/init.d/` and modify the `CONFFILE` and `command` parameter to your needs. 
 Then start cjdns by issuing
- /etc/init.d/cjdns start
+    /etc/init.d/cjdns start
 Configure the init system to autostart cjdns
- rc-update add cjdns default
+    rc-update add cjdns default
 
 Copy the service_restart script `contrib/gentoo/service_restart.sh` to any convenient directory on 
 your system and modify the eMail address. I you do not wish to be notified, comment out the whole line.
 Now add an crontab entry like this
- # Restart crashed Services
- * * * * *       root	/path/to/script/service_restart.sh
+    # Restart crashed Services
+    * * * * *       root	/path/to/script/service_restart.sh

--- a/contrib/gentoo/service_restart.sh
+++ b/contrib/gentoo/service_restart.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for svc in $(rc-status --crashed); do
+	rc-service $svc -- --nodeps restart
+	echo "$svc has crashed and has been restarted." | mail -s "$svc has been restarted." <your_email>
+done

--- a/contrib/openrc/cjdns
+++ b/contrib/openrc/cjdns
@@ -1,0 +1,32 @@
+#!/sbin/runscript
+description="Encrypted networking for regular people."
+
+CONFFILE=/etc/cjdroute.conf
+
+command="/usr/sbin/cjdroute"
+
+depend() {
+	use net dns
+	after precursor
+}
+
+start() {
+	if [ ! -e /dev/net/tun ]; then
+		ebegin "Inserting TUN module"
+        
+		if ! modprobe tun;  then
+            	eerror "Failed to insert TUN kernel module"
+            	exit 1
+        	fi
+    	fi
+
+    	ebegin "Starting CJDNS"
+    	start-stop-daemon --start --quiet --exec "${command}" -- < "${CONFFILE}" 
+    	eend $?
+}
+
+stop() {
+	ebegin "Stopping CJDNS"
+	start-stop-daemon --stop --exec "${command}" 
+	eend $?
+}

--- a/contrib/python/cjdnsadmin/adminTools.py
+++ b/contrib/python/cjdnsadmin/adminTools.py
@@ -77,7 +77,7 @@ def streamRoutingTable(cjdns, delay=10):
 
         sleep(delay)
 
-def peerStats(cjdns,up=False,verbose=False):
+def peerStats(cjdns,up=False,verbose=False,human_readable=False):
     from publicToIp6 import PublicToIp6_convert;
 
     allPeers = []
@@ -95,13 +95,19 @@ def peerStats(cjdns,up=False,verbose=False):
         i += 1
 
     if verbose:
-        STAT_FORMAT = '%s\tv%s\t%s\tin %d\tout %d\t%s\tdup %d los %d oor %d'
+        STAT_FORMAT = '%s\tv%s\t%s\tin %s\tout %s\t%s\tdup %d los %d oor %d'
 
         for peer in allPeers:
             ip = PublicToIp6_convert(peer['publicKey'])
-
+			
+            b_in  = peer['bytesIn']
+            b_out = peer['bytesOut']
+            if human_readable:
+				b_in  = sizeof_fmt(b_in)
+				b_out = sizeof_fmt(b_out)
+            
             p = STAT_FORMAT % (ip, peer['version'], peer['switchLabel'],
-                               peer['bytesIn'], peer['bytesOut'], peer['state'],
+                               str(b_in), str(b_out), peer['state'],
                                peer['duplicates'], peer['lostPackets'],
                                peer['receivedOutOfRange'])
 
@@ -110,6 +116,12 @@ def peerStats(cjdns,up=False,verbose=False):
 
             print p
     return allPeers
+
+def sizeof_fmt(num):
+    for x in ['B','KB','MB','GB','TB']:
+        if num < 1024.0:
+            return "%3.1f%s" % (num, x)
+        num /= 1024.0
 
 def parseLabel(route):
     route = route.replace('.','')

--- a/contrib/python/cjdnslog
+++ b/contrib/python/cjdnslog
@@ -34,24 +34,30 @@ def recieve(cjdns, txid):
         doLog(cjdns.getMessage(txid));
 
 
+def main():
+    cjdns = connectWithAdminInfo();
 
-cjdns = connectWithAdminInfo();
+    level = '';
+    fileName = '';
+    line = 0;
+    args = len(sys.argv) - 1;
+    if (args == 0):
+        usage();
+        exit(0);
 
-level = '';
-fileName = '';
-line = 0;
-args = len(sys.argv) - 1;
-if (args == 0):
-    usage();
-    exit(0);
+    if (args > 0): level = sys.argv[1];
+    if (args > 1): fileName = sys.argv[2];
+    if (args > 2): line = int(sys.argv[3]);
 
-if (args > 0): level = sys.argv[1];
-if (args > 1): fileName = sys.argv[2];
-if (args > 2): line = int(sys.argv[3]);
+    sub = cjdns.AdminLog_subscribe(line, fileName, level);
 
-sub = cjdns.AdminLog_subscribe(line, fileName, level);
+    if (sub['error'] == 'none'):
+        recieve(cjdns, sub['txid']);
+    else:
+        print(sub);
 
-if (sub['error'] == 'none'):
-    recieve(cjdns, sub['txid']);
-else:
-    print(sub);
+try:
+    main()
+except KeyboardInterrupt:
+    print("")
+    print("Interrupted by user.")

--- a/contrib/python/peerStats
+++ b/contrib/python/peerStats
@@ -11,10 +11,40 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+import getopt
 import cjdnsadmin.adminTools as at
 
-cjdns=at.anonConnect()
+def main():
 
-at.peerStats(cjdns,verbose=True);
+    human_readable=False
 
-cjdns.disconnect()
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "h" , ["humanreadable", "help"])
+    except getopt.GetoptError, e:
+        print(str(e))
+        print()
+        usage()
+        sys.exit(1)
+
+    for o, a in opts:
+        if o in ("-h", "--humanreadable"): human_readable=True
+        if o == ("--help"):
+            usage()
+            sys.exit(0)
+
+        
+
+    cjdns=at.anonConnect()
+    at.peerStats(cjdns,verbose=True,human_readable=human_readable);
+    cjdns.disconnect()
+
+
+def usage():
+    print("usage: peerStats [-h]")
+    print("")
+    print("     -h, --humanreadable     human readable output of transmitted bytes")
+    print("     --help                  this list")
+    print("")
+
+main()


### PR DESCRIPTION
Init script for cjdns on Gentoo running openrc.
Add human readability to python peerstats.
Add user interruption to python cjdnslog.
Add automatic crash detection and restart for Gentoo systems.