### PR TITLE
client: exit foreground process when core dies

### DIFF
--- a/client/cjdroute2.c
+++ b/client/cjdroute2.c
@@ -447,6 +447,11 @@ static void checkRunningInstance(struct Allocator* allocator,
     Allocator_free(alloc);
 }
 
+static void onCoreExit(int64_t exit_status, int term_signal)
+{
+    Assert_failure("Core exited with status [%d], signal [%d]\n", (int)exit_status, term_signal);
+}
+
 int main(int argc, char** argv)
 {
     #ifdef Log_KEYS
@@ -589,7 +594,7 @@ int main(int argc, char** argv)
     if (!privateKey) {
         Except_throw(eh, "Need to specify privateKey.");
     }
-    Process_spawn(corePath, args, eventBase, allocator);
+    Process_spawn(corePath, args, eventBase, allocator, onCoreExit);
 
     // --------------------- Pre-Configure Core ------------------------- //
     Dict* preConf = Dict_new(allocator);

--- a/util/events/Process.h
+++ b/util/events/Process.h
@@ -19,6 +19,9 @@
 #include "util/Linker.h"
 Linker_require("util/events/libuv/Process.c")
 
+#include <stdint.h>
+
+typedef void (* Process_OnExitCallback)(int64_t exit_status, int term_signal);
 
 /**
  * Spawn a new process.
@@ -27,9 +30,14 @@ Linker_require("util/events/libuv/Process.c")
  * @param args a list of strings representing the arguments to the command followed by NULL.
  * @param base the event base.
  * @param alloc an allocator. The process to be killed when it is freed.
+ * @param callback a function to be called when the spawn process exits.
  * @return 0 if all went well, -1 if forking fails.
  */
-int Process_spawn(char* binaryPath, char** args, struct EventBase* base, struct Allocator* alloc);
+int Process_spawn(char* binaryPath,
+                  char** args,
+                  struct EventBase* base,
+                  struct Allocator* alloc,
+                  Process_OnExitCallback callback);
 
 /**
  * Get the path to the binary of the current process.

--- a/util/test/Process_test.c
+++ b/util/test/Process_test.c
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
 
     char* args[] = { "Process_test", "child", name, NULL };
 
-    Assert_true(!Process_spawn(path, args, eb, alloc));
+    Assert_true(!Process_spawn(path, args, eb, alloc, NULL));
 
     Timeout_setTimeout(timeout, NULL, 2000, eb, alloc);
 

--- a/util/test/Seccomp_test.c
+++ b/util/test/Seccomp_test.c
@@ -118,7 +118,7 @@ int main(int argc, char** argv)
     char* path = Process_getPath(alloc);
     char* args[] = { "Seccomp_test", "child", name, NULL };
 
-    Assert_true(!Process_spawn(path, args, eb, alloc));
+    Assert_true(!Process_spawn(path, args, eb, alloc, NULL));
 
     Timeout_setTimeout(timeout, NULL, 2000, eb, alloc);
 


### PR DESCRIPTION
Many init scripts run cjdroute in foreground, so they can easily
send signals and fetch logs. They can however not monitor cjdroute,
because the foreground process doesn't keep track of the forked
core process. Thus recovery in case of crashes requires a manual
restart of cjdroute.

With this patch, once the core process exits, the foreground
process prints the exit code and the signal which caused the
exit. It then exits, too, and the init script can restart it.