### PR TITLE
seccomp: pragma message evades -Werror

### DIFF
--- a/util/Seccomp.c
+++ b/util/Seccomp.c
@@ -50,7 +50,7 @@
 #if defined(si_syscall)
 # define GET_SYSCALL_NUM(si) ((si)->si_syscall)
 #else
-# warning "your libc doesn't define SIGSYS signal info!"
+# pragma message "your libc doesn't define SIGSYS signal info!"
 # define GET_SYSCALL_NUM(si) ((si)->si_value.sival_int)
 #endif
 


### PR DESCRIPTION
kernel: ```Linux kali 3.14.27.squeeze```

compiling:

```
/cjdns/node_build/builder.js:433
                if (err) { throw err; }
                                 ^
Error: gcc -E -std=c99 -Wall -Wextra -Werror -Wno-pointer-sign -pedantic -D linux=1 -Wno-unused-parameter -fomit-frame-pointer -D Log_DEBUG -g -D NumberCompress_TYPE=v3x5x8 -D Identity_CHECK=1 -D Allocator_USE_CANARIES=1 -D PARANOIA=1 -DHAS_ETH_INTERFACE=1 -fPIE -fno-stack-protector -fstack-protector-all -Wstack-protector -O3 -I . -I build_linux/dependencies/cnacl/jsbuild/include/ -I build_linux/dependencies/libuv/include/ util/Seccomp.c

util/Seccomp.c:53:3: error: #warning is a GCC extension [-Werror]
util/Seccomp.c:53:3: error: #warning "your libc doesn't define SIGSYS signal info!" [-Werror=cpp]
cc1: all warnings being treated as errors

    at error (/cjdns/node_build/builder.js:52:15)
    at /cjdns/node_build/builder.js:115:22
    at /cjdns/node_build/builder.js:85:13
    at ChildProcess.<anonymous> (/cjdns/node_build/Semaphore.js:7:30)
    at ChildProcess.EventEmitter.emit (events.js:103:17)
    at maybeClose (child_process.js:735:16)
    at Process.ChildProcess._handle.onexit (child_process.js:802:5)
```

patched:

```
Building C object interface/tuntap/BSDMessageTypeWrapper.c complete
Building C object dht/dhtcore/VersionList.c complete
Building C object dht/dhtcore/RumorMill.c complete
Building C object dht/dhtcore/Node.c complete
Building C object switch/EncodingScheme.c complete
Building C object crypto/random/test/DeterminentRandomSeed.c complete
util/Seccomp.c:53:9: note: #pragma message: your libc doesn't define SIGSYS signal info!

Building C object util/Seccomp.c complete
Building C object util/AverageRoller.c complete
Building C object util/Order.c complete
Building C object dht/DHTModuleRegistry.c complete
Building C object test/TestFramework.c complete
Building C object util/ArrayList.c complete
Has setuid keepNetAdmin
Building C object net/PeerLink.c complete
```
