### PR TITLE
Multiple android build fixes

### DIFF
--- a/android_do
+++ b/android_do
@@ -69,6 +69,7 @@ mkdir $(pwd)/android_out/x86
 #arm build
 rm -rf build_linux
 
+export PLATFORM=android
 export SYSTEM=linux
 
 export CROSS_COMPILE=$BUILD_PATH/arm-${TYPE}-androideabi/bin/arm-linux-androideabi-
@@ -79,6 +80,7 @@ export AR=${CROSS}ar
 export RANLIB=${CROSS}ranlib
 export CFLAGS=${CROSS_CFLAGS}
 export LDFLAGS=${CROSS_LDFLAGS}
+
 gcc_version=$(${CC} --version)
 echo Using $gcc_version
 echo Compiler CC: $CC
@@ -99,13 +101,16 @@ rm cjdroute
 rm -rf build_linux
 
 export CROSS_COMPILE=$BUILD_PATH/i686-${TYPE}-androideabi/bin/i686-linux-android-
-export TARGET_ARCH=x64
 export CROSS=${CROSS_COMPILE}
-export CC=${CROSS}gcc
+export TARGET_ARCH=x64
 export AR=${CROSS}ar
+export CC=${CROSS}gcc
+export CXX=${CROSS}g++
+export LINK=${CROSS}g++
 export RANLIB=${CROSS}ranlib
 export CFLAGS=${CROSS_CFLAGS}
 export LDFLAGS=${CROSS_LDFLAGS}
+
 gcc_version=$(${CC} --version)
 echo Using $gcc_version
 echo Compiler CC: $CC

--- a/node_build/dependencies/libuv/android-configure
+++ b/node_build/dependencies/libuv/android-configure
@@ -3,7 +3,7 @@
 export TOOLCHAIN=$PWD/android-toolchain
 mkdir -p $TOOLCHAIN
 $1/build/tools/make-standalone-toolchain.sh \
-    --toolchain=arm-linux-androideabi-4.7 \
+    --toolchain=arm-linux-androideabi-4.8 \
     --arch=arm \
     --install-dir=$TOOLCHAIN \
     --platform=android-9
@@ -16,5 +16,5 @@ export PLATFORM=android
 
 if [ $2 -a $2 == 'gyp' ]
   then
-    ./gyp_uv.py -Dtarget_arch=arm -DOS=android
+    ./gyp_uv.py -Dtarget_arch=arm -DOS=android -f make-android
 fi

--- a/node_build/dependencies/libuv/common.gypi
+++ b/node_build/dependencies/libuv/common.gypi
@@ -42,6 +42,10 @@
           ['OS != "win"', {
             'defines': [ 'EV_VERIFY=2' ],
           }],
+          ['OS == "android"', {
+            'cflags': [ '-fPIE' ],
+            'ldflags': [ '-fPIE', '-pie' ]
+          }],
         ]
       },
       'Release': {

--- a/node_build/make.js
+++ b/node_build/make.js
@@ -339,9 +339,6 @@ Builder.configure({
             }
 
             //args.push('--root-target=libuv');
-            if (android) {
-                args.push('-DOS=android');
-            }
 
             if (builder.config.systemName === 'win32') {
                 args.push('-DOS=win');
@@ -354,6 +351,12 @@ Builder.configure({
             if (['freebsd', 'openbsd'].indexOf(builder.config.systemName) !== -1) {
                 // This platform lacks a functioning sem_open implementation, therefore...
                 args.push('--no-parallel');
+            }
+
+            if (android) {
+                args.push('-DOS=android');
+                args.push('-f');
+                args.push('make-android');
             }
 
             var gyp = Spawn(python, args, {env:env, stdio:'inherit'});


### PR DESCRIPTION
1. This commit uses gyp from the current maintained project.
2. Builds libuv from a commit which has ndk build fixes on the v1.x branch.
3. Fixes compiler issues with gcc related to function pointer types.
4. Passes proper build flags to libuv when building android
