### PR TITLE
Propagate the changes from #74 to upstart script

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -10,10 +10,11 @@ respawn
 respawn limit 2 300
 
 pre-start script
-    if ! [ -e /etc/cjdroute.conf ]; then
+    if ! [ -s /etc/cjdroute.conf ]; then
         ( # start a subshell to avoid side effects of umask later on
             umask 077 # to create the file with 600 permissions without races
-            /usr/bin/cjdroute --genconf > /etc/cjdroute.conf
+            conf=$(cjdroute --genconf) # if this fails we'll exit *before* we create the config file
+            echo "$conf" > /etc/cjdroute.conf
         ) # exit subshell; umask no longer applies
         echo 'WARNING: A new cjdns cjdroute.conf file has been generated.'
     fi


### PR DESCRIPTION
Fix config generation failing permanently with a blank config file if cjdroute binary is not in $PATH the first time around. 
Should never happen in .deb packages, but it's a reasonable robustness improvement nevertheless.