### PR TITLE
Propagate the changes from #74 to upstart script

### DIFF
--- a/contrib/upstart/cjdns.conf
+++ b/contrib/upstart/cjdns.conf
@@ -10,7 +10,7 @@ respawn
 respawn limit 2 300
 
 pre-start script
-    if ! [ -e /etc/cjdroute.conf ]; then
+    if ! [ -s /etc/cjdroute.conf ]; then
         ( # start a subshell to avoid side effects of umask later on
             umask 077 # to create the file with 600 permissions without races
             /usr/bin/cjdroute --genconf > /etc/cjdroute.conf


### PR DESCRIPTION
Fix config generation failing permanently with a blank config file if cjdroute binary is not in $PATH the first time around.
Should never happen in .deb packages (where this config is most used), but it's a reasonable robustness improvement nevertheless.