### PR TITLE
Fix long outgoing references blocking cjdroute

### DIFF
--- a/benc/serialization/standard/BencMessageWriter.h
+++ b/benc/serialization/standard/BencMessageWriter.h
@@ -23,4 +23,11 @@ Linker_require("benc/serialization/standard/BencMessageWriter.c")
 
 void BencMessageWriter_write(Dict* toWrite, struct Message* msg, struct Except* eh);
 
+/**
+ * this function is a non-static wrapper for same function,
+ * so that we can use it from other places to estimate if reference
+ * will fit in admin UDP packet
+ */
+int BencMessageWriter_writeDictTry(Dict* d, struct Message* msg, struct Except* eh);
+
 #endif


### PR DESCRIPTION
Too long text of reference in outgoing peers
(in connectTo) is handled correctly:

We send to cjdroute (via UDP packet) only
the needed data, skipping the fields
that are not used.

Also, if anyway the reference is still too large
(e.g. had very long password), it will be skipped
with an error logged.