### PR TITLE
fix codestyle error

### DIFF
--- a/interface/tuntap/TUNInterface_openbsd.c
+++ b/interface/tuntap/TUNInterface_openbsd.c
@@ -69,7 +69,7 @@ struct Iface* TUNInterface_new(const char* interfaceName,
     // Since devices are numbered rather than named, it's not possible to have tun0 and cjdns0
     // so we'll skip the pretty names and call everything tunX
     if (assignedInterfaceName) {
-        if(ppa == -1) {
+        if (ppa == -1) {
             snprintf(assignedInterfaceName, TUNInterface_IFNAMSIZ, "%s", interfaceName);
         } else {
             snprintf(assignedInterfaceName, TUNInterface_IFNAMSIZ, "tun%d", ppa);


### PR DESCRIPTION
This error prevents top-level ./do script from returning with zero code.