### PR TITLE
Make cjdns.service report active after TUN has IP

### DIFF
--- a/contrib/systemd/cjdns.service
+++ b/contrib/systemd/cjdns.service
@@ -4,6 +4,7 @@ Wants=network.target
 After=network.target
 
 [Service]
+Type=notify
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=cjdroute
@@ -12,7 +13,7 @@ ExecStartPre=/bin/sh -ec "if ! test -s /etc/cjdroute.conf; \
                 /usr/bin/cjdroute --genconf > /etc/cjdroute.conf; \
                 echo 'WARNING: A new /etc/cjdroute.conf file has been generated.'; \
             fi"
-ExecStart=/bin/sh -c "exec cjdroute --nobg < /etc/cjdroute.conf"
+ExecStart=/usr/lib/systemd/scripts/start-cjdns.sh
 Restart=always
 
 [Install]

--- a/contrib/systemd/start-cjdns.sh
+++ b/contrib/systemd/start-cjdns.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -
+nohup cjdroute --nobg < /etc/cjdroute.conf &
+PID=$!
+while ! ip -6 a | grep 'inet6 fc' >/dev/null; do
+	if ! jobs -p | grep $PID >/dev/null; then
+		echo 'cjdroute failed' >2
+		exit 2
+	fi
+	sleep 1
+done
+systemd-notify READY=1
+# this trick is so systemd doesn't think that cjdroute is alien
+# this process has to exit so cjdroute process is direct child of
+# systemd runner, warning about alien will still show but
+# it isn't important in any way as alien process exits
+# right away
+nohup sh -c "sleep 1 && systemd-notify MAINPID=$PID" &
+systemd-notify MAINPID=$!


### PR DESCRIPTION
It solves problems when you want to run services with
After=cjdns.service
that want to bind IP provided by cjdns
In my case it is nginx that fails to start otherwise.
This change will require changes in packaging.
